### PR TITLE
Linked events rework

### DIFF
--- a/packages/client/src/components/AttendanceView.tsx
+++ b/packages/client/src/components/AttendanceView.tsx
@@ -27,7 +27,7 @@ import {
 	effectiveManageEventPermissionForEvent,
 	Member,
 	NewAttendanceRecord,
-	RawEventObject,
+	RawResolvedEventObject,
 	RegistryValues,
 	User,
 } from 'common-lib';
@@ -50,7 +50,7 @@ const renderCustomAttendanceField = (attendanceFieldItem: CustomAttendanceFieldV
 	);
 
 interface AttendanceItemViewProps {
-	owningEvent: RawEventObject;
+	owningEvent: RawResolvedEventObject;
 	owningAccount: AccountObject;
 	member: User;
 	registry: RegistryValues;

--- a/packages/client/src/components/forms/usable-forms/AttendanceForm.tsx
+++ b/packages/client/src/components/forms/usable-forms/AttendanceForm.tsx
@@ -26,13 +26,13 @@ import {
 	CustomAttendanceFieldValue,
 	effectiveManageEventPermissionForEvent,
 	Either,
+	Member,
 	NewAttendanceRecord,
 	Permissions,
-	RawEventObject,
+	RawResolvedEventObject,
 	RegistryValues,
 	toReference,
 	User,
-	Member,
 } from 'common-lib';
 import * as React from 'react';
 import fetchApi, { fetchAPIForAccount } from '../../../lib/apis';
@@ -57,7 +57,7 @@ type FormState = NewAttendanceRecord & { usePartTime: boolean };
 export interface AttendanceFormProps {
 	account: AccountObject;
 	member: User;
-	event: RawEventObject;
+	event: RawResolvedEventObject;
 	registry: RegistryValues;
 	record?: AttendanceRecord;
 	updateRecord: (record: Required<NewAttendanceRecord>, member: Member) => void;
@@ -355,7 +355,10 @@ export default class AttendanceForm extends React.Component<
 		);
 	}
 
-	private getCustomFields(event: RawEventObject, rawFields: CustomAttendanceFieldValue[]) {
+	private getCustomFields(
+		event: RawResolvedEventObject,
+		rawFields: CustomAttendanceFieldValue[],
+	) {
 		if (this.props.record) {
 			if (effectiveManageEventPermissionForEvent(this.props.member)(event)) {
 				const fields = rawFields;

--- a/packages/client/src/pages/Calendar.tsx
+++ b/packages/client/src/pages/Calendar.tsx
@@ -17,7 +17,7 @@
  * along with EvMPlus.org.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Either, RawEventObject, Timezone } from 'common-lib';
+import { Either, RawEventObject, Timezone, RawResolvedEventObject } from 'common-lib';
 import { DateTime, Duration } from 'luxon';
 import React from 'react';
 import Loader from '../components/Loader';
@@ -94,7 +94,7 @@ export const getPositionIndices = (
 };
 
 export interface CalendarProps extends PageProps<{ month?: string; year?: string }> {
-	events: RawEventObject[];
+	events: RawResolvedEventObject[];
 	start: DateTime;
 	end: DateTime;
 }
@@ -104,7 +104,7 @@ export default class Calendar extends Page<
 	{ events: RawEventObject[] | null; start: DateTime | null; end: DateTime | null }
 > {
 	public state: {
-		events: RawEventObject[] | null;
+		events: RawResolvedEventObject[] | null;
 		start: DateTime | null;
 		end: DateTime | null;
 	} = {

--- a/packages/client/src/pages/Main.tsx
+++ b/packages/client/src/pages/Main.tsx
@@ -20,8 +20,8 @@
 import {
 	AsyncEither,
 	asyncRight,
-	CadetPromotionStatus,
 	CadetPromotionRequirementsMap,
+	CadetPromotionStatus,
 	Either,
 	errorGenerator,
 	EventStatus,
@@ -32,7 +32,7 @@ import {
 	MaybeObj,
 	pipe,
 	presentMultCheckboxReturn,
-	RawEventObject,
+	RawResolvedEventObject,
 } from 'common-lib';
 import { DateTime } from 'luxon';
 import * as React from 'react';
@@ -50,8 +50,8 @@ interface MainStateUnloaded {
 
 interface MainStateLoaded {
 	state: 'LOADED';
-	events: RawEventObject[];
-	nextEvent: MaybeObj<RawEventObject>;
+	events: RawResolvedEventObject[];
+	nextEvent: MaybeObj<RawResolvedEventObject>;
 	promotionRequirements: MaybeObj<CadetPromotionStatus>;
 }
 

--- a/packages/client/src/pages/calendars/DesktopCalendar.tsx
+++ b/packages/client/src/pages/calendars/DesktopCalendar.tsx
@@ -18,18 +18,18 @@
  */
 
 import {
-	RawEventObject,
-	EventStatus,
 	effectiveManageEventPermission,
+	EventStatus,
 	Permissions,
+	RawResolvedEventObject,
 } from 'common-lib';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { MONTHS } from '../../components/form-inputs/DateTimeInput';
 import { CalendarProps, getMonth, getPositionIndices } from '../Calendar';
 import Page from '../Page';
 import './DesktopCalendar.css';
-import { MONTHS } from '../../components/form-inputs/DateTimeInput';
 
 export type CalendarData = Array<
 	Array<{
@@ -38,7 +38,7 @@ export type CalendarData = Array<
 		year: number;
 		events: Array<
 			| {
-					event: RawEventObject;
+					event: RawResolvedEventObject;
 					width: number;
 					block: boolean;
 					mergeLeft: boolean;
@@ -75,7 +75,7 @@ const findIndex = (calendar: CalendarData, startDay: number, endDay: number, wee
 	return testIndex;
 };
 
-export const getClassNameFromEvent = (obj: RawEventObject) => {
+export const getClassNameFromEvent = (obj: RawResolvedEventObject) => {
 	switch (obj.status) {
 		case EventStatus.CANCELLED:
 			return ' cancelled';

--- a/packages/client/src/pages/calendars/MobileCalendar.tsx
+++ b/packages/client/src/pages/calendars/MobileCalendar.tsx
@@ -17,7 +17,7 @@
  * along with EvMPlus.org.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RawEventObject, effectiveManageEventPermission, Permissions } from 'common-lib';
+import { effectiveManageEventPermission, Permissions, RawResolvedEventObject } from 'common-lib';
 import { DateTime } from 'luxon';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -98,7 +98,7 @@ export default class MobileCalendar extends Page<CalendarProps> {
 	}
 
 	private renderEventListForDay = (month: DateTime) => (
-		events: RawEventObject[],
+		events: RawResolvedEventObject[],
 		index: number,
 	) => {
 		if (events.length === 0) {

--- a/packages/client/src/pages/events/EventLinkList.tsx
+++ b/packages/client/src/pages/events/EventLinkList.tsx
@@ -22,15 +22,16 @@ import {
 	Either,
 	EventStatus,
 	RadioReturnWithOther,
-	RawEventObject,
+	RawResolvedEventObject,
+	EventType,
 } from 'common-lib';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import Loader from '../../components/Loader';
 import fetchApi from '../../lib/apis';
-import './EventLinkList.css';
 import Page, { PageProps } from '../Page';
+import './EventLinkList.css';
 
 interface EventLinkListLoadingState {
 	state: 'LOADING';
@@ -39,8 +40,8 @@ interface EventLinkListLoadingState {
 interface EventLinkListLoadedState {
 	state: 'LOADED';
 
-	events: RawEventObject[];
-	eventsThatAreLinked: RawEventObject[];
+	events: RawResolvedEventObject[];
+	eventsThatAreLinked: RawResolvedEventObject[];
 }
 
 interface EventLinkListErrorState {
@@ -124,7 +125,7 @@ export default class EventLinkList extends Page<PageProps, EventLinkListState> {
 					event => event.startDateTime > +DateTime.utc() - 13 * 60 * 60 * 24 * 30 * 1000,
 				);
 
-				const eventsThatAreLinked = events.filter(event => !!event.sourceEvent);
+				const eventsThatAreLinked = events.filter(event => event.type === EventType.LINKED);
 
 				this.setState({
 					state: 'LOADED',
@@ -180,15 +181,15 @@ export default class EventLinkList extends Page<PageProps, EventLinkListState> {
 									{event.accountID}-{event.id} ::{'  '}
 									<Link to={`/eventform/${event.id}`}>{event.name}</Link>
 									{` `}
-									{event.sourceEvent ? (
+									{event.type === EventType.LINKED ? (
 										<>
 											{` - [`}
 											<a
-												href={`https://${event.sourceEvent.accountID}.${process.env.REACT_APP_HOST_NAME}/eventviewer/${event.sourceEvent.id}`}
+												href={`https://${event.targetAccountID}.${process.env.REACT_APP_HOST_NAME}/eventviewer/${event.targetEventID}`}
 												target="_blank"
 												rel="noopener noreferrer"
 											>
-												{event.sourceEvent.accountID}-{event.sourceEvent.id}
+												{event.targetAccountID}-{event.targetEventID}
 											</a>
 											{`]`}
 										</>

--- a/packages/client/src/pages/events/EventViewer.tsx
+++ b/packages/client/src/pages/events/EventViewer.tsx
@@ -35,6 +35,7 @@ import {
 	EitherObj,
 	EventObject,
 	EventStatus,
+	EventType,
 	formatEventViewerDate as formatDate,
 	forms,
 	FullTeamObject,
@@ -44,6 +45,7 @@ import {
 	getMemberPhone,
 	getURIComponent,
 	HTTPError,
+	labels,
 	Maybe,
 	MaybeObj,
 	Member,
@@ -55,10 +57,9 @@ import {
 	pipe,
 	PointOfContactType,
 	presentMultCheckboxReturn,
-	RawEventObject,
+	RawResolvedEventObject,
 	Right,
 	spreadsheets,
-	labels,
 	stringifyMemberReference,
 	User,
 } from 'common-lib';
@@ -73,12 +74,12 @@ import DialogueButtonForm from '../../components/dialogues/DialogueButtonForm';
 import DownloadDialogue from '../../components/dialogues/DownloadDialogue';
 import DropDownList from '../../components/DropDownList';
 import {
+	Checkbox,
 	DateTimeInput,
 	Label,
+	SimpleRadioButton,
 	TextBox,
 	TextInput,
-	Checkbox,
-	SimpleRadioButton,
 } from '../../components/forms/SimpleForm';
 import AttendanceForm from '../../components/forms/usable-forms/AttendanceForm';
 import Loader from '../../components/Loader';
@@ -171,7 +172,7 @@ export const attendanceStatusLabels = [
 	'Rescinded commitment to attend',
 ];
 
-const renderName = (renderMember: User | null) => (event: RawEventObject) => (
+const renderName = (renderMember: User | null) => (event: RawResolvedEventObject) => (
 	member: api.events.events.EventViewerAttendanceRecord,
 ) => {
 	const defaultRenderName = `${member.record.memberID.id}: ${member.record.memberName}`;
@@ -550,10 +551,10 @@ export default class EventViewer extends Page<EventViewerProps, EventViewerState
 					{member &&
 					effectiveManageEventPermissionForEvent(member)(event) &&
 					linkableAccounts.length > 0 &&
-					!event.sourceEvent ? (
+					event.type !== EventType.LINKED ? (
 						<br />
 					) : null}
-					{!!event.sourceEvent ||
+					{event.type === EventType.LINKED ||
 					linkableAccounts.length === 0 ? null : linkableAccounts.length === 1 ? (
 						<Button
 							onClick={() => this.linkEventTo(linkableAccounts[0].id)}
@@ -641,30 +642,31 @@ export default class EventViewer extends Page<EventViewerProps, EventViewerState
 					effectiveManageEventPermissionForEvent(member)(event) >=
 						Permissions.ManageEvent.FULL ? (
 						<>
-							{linkableAccounts.length === 0 || !!event.sourceEvent ? <br /> : null}
+							{linkableAccounts.length === 0 || event.type === EventType.LINKED ? (
+								<br />
+							) : null}
 							<Link to={`/events/scanadd/${event.id}`}>Attendance scanner</Link>
 						</>
 					) : null}
 					{(member && effectiveManageEventPermissionForEvent(member)(event)) ||
 					(fullMemberDetails.error === MemberCreateError.NONE &&
 						fullMemberDetails.linkableAccounts.length > 0 &&
-						event.sourceEvent === null) ? (
+						event.type === EventType.REGULAR) ? (
 						<>
 							<br />
 							<br />
 						</>
 					) : null}
 					<div id="information">
-						{event.sourceEvent ? (
+						{event.type === EventType.LINKED ? (
 							<>
 								<strong>
 									<a
-										href={`https://${event.sourceEvent.accountID}.${process.env.REACT_APP_HOST_NAME}/eventviewer/${event.sourceEvent.id}`}
+										href={`https://${event.targetAccountID}.${process.env.REACT_APP_HOST_NAME}/eventviewer/${event.targetEventID}`}
 										rel="noopener _blank"
 									>
 										Event linked from{' '}
-										{sourceAccountName ??
-											event.sourceEvent.accountID.toUpperCase()}
+										{sourceAccountName ?? event.targetAccountID.toUpperCase()}
 									</a>
 								</strong>
 								<br />

--- a/packages/common-lib/src/lib/Events.ts
+++ b/packages/common-lib/src/lib/Events.ts
@@ -23,14 +23,13 @@ import {
 	CustomAttendanceField,
 	CustomAttendanceFieldEntryType,
 	CustomAttendanceFieldValue,
+	EventObject,
 	EventType,
 	MemberReference,
 	Permissions,
 	PointOfContactType,
-	RawRegularEventObject,
 	RawResolvedEventObject,
 	RawTeamObject,
-	RegularEventObject,
 	User,
 } from '../typings/types';
 import { Either, EitherObj } from './Either';
@@ -57,7 +56,7 @@ export const isPOCOf = (member: MemberReference, event: RawResolvedEventObject) 
 		)
 		.reduce((prev, curr) => prev || curr, false);
 
-export const canSignUpForEvent = (event: RegularEventObject) => (
+export const canSignUpForEvent = (event: EventObject) => (
 	eventTeam: MaybeObj<RawTeamObject>,
 ): ((memberInput?: MemberReference | null) => EitherObj<string, void>) =>
 	pipe(
@@ -87,10 +86,10 @@ export const canSignUpForEvent = (event: RegularEventObject) => (
 		Either.map(destroy),
 	);
 
-export const getURIComponent = (event: RawRegularEventObject) =>
+export const getURIComponent = (event: RawResolvedEventObject) =>
 	`${event.id}-${event.name.toLocaleLowerCase().replace(/ /g, '-')}`;
 
-export const hasMember = (event: RegularEventObject) => (member: MemberReference) =>
+export const hasMember = (event: EventObject) => (member: MemberReference) =>
 	event.attendance.map(get('memberID')).filter(areMembersTheSame(member)).length > 0;
 
 export const hasBasicEventPermissions = (member: User) =>

--- a/packages/common-lib/src/renderers/forms/capf6080.ts
+++ b/packages/common-lib/src/renderers/forms/capf6080.ts
@@ -21,7 +21,7 @@ import { DateTime } from 'luxon';
 import type { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { presentMultCheckboxReturn } from '../../lib/forms';
 import { Maybe } from '../../lib/Maybe';
-import { FullPointOfContact, Member, RawEventObject } from '../../typings/types';
+import { FullPointOfContact, Member, RawRegularEventObject } from '../../typings/types';
 
 export function formatPhone(phone: string) {
 	// strip spaces and non-numeric characters
@@ -160,7 +160,7 @@ const GetBestEmails = (inMember: Member) => {
 	}
 };
 
-const GetOtherForms = (inEvent: RawEventObject) => {
+const GetOtherForms = (inEvent: RawRegularEventObject) => {
 	if (inEvent.requiredForms.otherSelected) {
 		return inEvent.requiredForms.otherValue;
 	} else {
@@ -169,7 +169,7 @@ const GetOtherForms = (inEvent: RawEventObject) => {
 };
 
 export const capf6080DocumentDefinition = (
-	event: RawEventObject,
+	event: RawRegularEventObject,
 	pointsOfContact: FullPointOfContact[],
 	member: Member,
 	hostname: string,

--- a/packages/common-lib/src/renderers/forms/capf6080.ts
+++ b/packages/common-lib/src/renderers/forms/capf6080.ts
@@ -21,7 +21,7 @@ import { DateTime } from 'luxon';
 import type { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { presentMultCheckboxReturn } from '../../lib/forms';
 import { Maybe } from '../../lib/Maybe';
-import { FullPointOfContact, Member, RawRegularEventObject } from '../../typings/types';
+import { FullPointOfContact, Member, RawResolvedEventObject } from '../../typings/types';
 
 export function formatPhone(phone: string) {
 	// strip spaces and non-numeric characters
@@ -160,7 +160,7 @@ const GetBestEmails = (inMember: Member) => {
 	}
 };
 
-const GetOtherForms = (inEvent: RawRegularEventObject) => {
+const GetOtherForms = (inEvent: RawResolvedEventObject) => {
 	if (inEvent.requiredForms.otherSelected) {
 		return inEvent.requiredForms.otherValue;
 	} else {
@@ -169,7 +169,7 @@ const GetOtherForms = (inEvent: RawRegularEventObject) => {
 };
 
 export const capf6080DocumentDefinition = (
-	event: RawRegularEventObject,
+	event: RawResolvedEventObject,
 	pointsOfContact: FullPointOfContact[],
 	member: Member,
 	hostname: string,

--- a/packages/common-lib/src/renderers/spreadsheets/AttendanceXlsx.ts
+++ b/packages/common-lib/src/renderers/spreadsheets/AttendanceXlsx.ts
@@ -25,7 +25,7 @@ import {
 	CustomAttendanceField,
 	CustomAttendanceFieldEntryType,
 	Member,
-	RawRegularEventObject,
+	RawResolvedEventObject,
 } from '../../typings/types';
 
 const EventStatus = [
@@ -133,7 +133,7 @@ const GetBestEmails = (inMember: Member) => {
 
 const CustomAttendanceFieldType = ['Text', 'Number', 'Date', 'Checkbox', 'File'];
 
-export const EventXL = (event: RawRegularEventObject): Array<Array<string | number>> => {
+export const EventXL = (event: RawResolvedEventObject): Array<Array<string | number>> => {
 	let row: Array<string | number> = [
 		'EvMPlus.org Event Information and Sign-up/Attendance Roster',
 	];
@@ -240,7 +240,7 @@ export const FormatEventXL = (evt: string, sheet: XLSX.Sheet, hostname: string):
 };
 
 export const AttendanceXL = (
-	event: RawRegularEventObject,
+	event: RawResolvedEventObject,
 	attendance: EventViewerAttendanceRecord[],
 ): [Array<Array<string | number>>, number[]] => {
 	let widths: number[] = [];

--- a/packages/common-lib/src/renderers/spreadsheets/AttendanceXlsx.ts
+++ b/packages/common-lib/src/renderers/spreadsheets/AttendanceXlsx.ts
@@ -25,7 +25,7 @@ import {
 	CustomAttendanceField,
 	CustomAttendanceFieldEntryType,
 	Member,
-	RawEventObject,
+	RawRegularEventObject,
 } from '../../typings/types';
 
 const EventStatus = [
@@ -133,7 +133,7 @@ const GetBestEmails = (inMember: Member) => {
 
 const CustomAttendanceFieldType = ['Text', 'Number', 'Date', 'Checkbox', 'File'];
 
-export const EventXL = (event: RawEventObject): Array<Array<string | number>> => {
+export const EventXL = (event: RawRegularEventObject): Array<Array<string | number>> => {
 	let row: Array<string | number> = [
 		'EvMPlus.org Event Information and Sign-up/Attendance Roster',
 	];
@@ -240,7 +240,7 @@ export const FormatEventXL = (evt: string, sheet: XLSX.Sheet, hostname: string):
 };
 
 export const AttendanceXL = (
-	event: RawEventObject,
+	event: RawRegularEventObject,
 	attendance: EventViewerAttendanceRecord[],
 ): [Array<Array<string | number>>, number[]] => {
 	let widths: number[] = [];

--- a/packages/common-lib/src/typings/apis/events/attendance.ts
+++ b/packages/common-lib/src/typings/apis/events/attendance.ts
@@ -82,12 +82,9 @@ export interface AddBulk {
 
 /**
  * Removes the member from attendance
- *
- * If a member is specified in the request body and the requester has permission, the member in the request body is removed
- * Otherwise, the person making the request is removed
  */
 export interface Delete {
-	(params: { id: string }, body: { member?: MemberReference }): APIEither<void>;
+	(params: { id: string }, body: { member: MemberReference }): APIEither<void>;
 
 	url: '/api/events/:id/attendance';
 

--- a/packages/common-lib/src/typings/apis/events/events.ts
+++ b/packages/common-lib/src/typings/apis/events/events.ts
@@ -31,7 +31,6 @@ import {
 	ExternalPointOfContact,
 	Member,
 	NewEventObject,
-	RawEventObject,
 	RawResolvedEventObject,
 } from '../../types';
 
@@ -110,7 +109,7 @@ export interface Copy {
  * TODO: Allow this to be done
  */
 export interface GetList {
-	(params: {}, body: {}): APIEither<RawEventObject[]>;
+	(params: {}, body: {}): APIEither<RawResolvedEventObject[]>;
 
 	url: '/api/events';
 
@@ -167,7 +166,7 @@ export interface GetEventViewerData {
  * Get's the next meeting with the 'Recurring Meeting' activity type set
  */
 export interface GetNextRecurring {
-	(params: {}, body: {}): APIEither<MaybeObj<RawEventObject>>;
+	(params: {}, body: {}): APIEither<MaybeObj<RawResolvedEventObject>>;
 
 	url: '/api/events/recurring';
 
@@ -184,7 +183,9 @@ export interface GetNextRecurring {
  * Creates a link between the specified account and event
  */
 export interface Link {
-	(params: { eventid: string; targetaccount: string }, body: {}): APIEither<RawEventObject>;
+	(params: { eventid: string; targetaccount: string }, body: {}): APIEither<
+		RawResolvedEventObject
+	>;
 
 	url: '/api/events/:eventid/link/:targetaccount';
 
@@ -201,7 +202,7 @@ export interface Link {
  * Gets the next `X` events, where `X` is defined in the Registry as `Website.ShowUpcomingEventCount`
  */
 export interface GetUpcoming {
-	(params: {}, body: {}): APIEither<RawEventObject[]>;
+	(params: {}, body: {}): APIEither<RawResolvedEventObject[]>;
 
 	url: '/api/events/upcoming';
 
@@ -255,7 +256,7 @@ export interface Delete {
  * from Date.now()
  */
 export interface GetRange {
-	(params: { timestart: string; timeend: string }, body: {}): APIEither<RawEventObject[]>;
+	(params: { timestart: string; timeend: string }, body: {}): APIEither<RawResolvedEventObject[]>;
 
 	url: '/api/events/:timestart/:timeend';
 

--- a/packages/common-lib/src/typings/apis/events/events.ts
+++ b/packages/common-lib/src/typings/apis/events/events.ts
@@ -32,6 +32,7 @@ import {
 	Member,
 	NewEventObject,
 	RawEventObject,
+	RawResolvedEventObject,
 } from '../../types';
 
 /**
@@ -47,7 +48,7 @@ export interface EventViewerAttendanceRecord {
  * Contains information needed to display an event in EVentViewer.tsx
  */
 export interface EventViewerData {
-	event: RawEventObject;
+	event: RawResolvedEventObject;
 	pointsOfContact: Array<DisplayInternalPointOfContact | ExternalPointOfContact>;
 	attendees: Array<APIEither<EventViewerAttendanceRecord>>;
 	sourceAccountName?: string | undefined;

--- a/packages/common-lib/src/typings/types.ts
+++ b/packages/common-lib/src/typings/types.ts
@@ -1013,7 +1013,7 @@ export interface DebriefItem extends NewDebriefItem {
 
 export type RawPointOfContact = InternalPointOfContact | ExternalPointOfContact;
 
-export interface RawEventObject extends AccountIdentifiable, NewEventObject {
+export interface RawRegularEventObject extends AccountIdentifiable, NewEventObject {
 	/**
 	 * ID of the Event, can be expressed as the event number
 	 */
@@ -1039,14 +1039,20 @@ export interface RawEventObject extends AccountIdentifiable, NewEventObject {
 	googleCalendarIds: {
 		/**
 		 * UUID of the Google Caldendar event on the main calendar
+		 *
+		 * Is null when the event is not to be published, such as a draft event
 		 */
 		mainId?: null | string;
 		/**
 		 * UUID of the Google Calendar registration deadline event on the main calendar
+		 *
+		 * Not present if there is no registration deadline
 		 */
 		regId?: null | string;
 		/**
 		 * UUID of the Goodle Calendar fee deadline event on the main calendar
+		 *
+		 * Not present if there is not a fee deadline
 		 */
 		feeId?: null | string;
 	};
@@ -1072,6 +1078,16 @@ export interface RawLinkedEvent extends AccountIdentifiable {
 	 */
 	targetAccountID: string;
 	/**
+	 * Mirrors the information for a regular event object. This is present
+	 * because a Google calendar will need items for the linked events as
+	 * well
+	 */
+	googleCalendarIds: {
+		mainId?: null | string;
+		regId?: null | string;
+		feeId?: null | string;
+	};
+	/**
 	 * Specify that this is a linked event
 	 */
 	type: EventType.LINKED;
@@ -1080,7 +1096,7 @@ export interface RawLinkedEvent extends AccountIdentifiable {
 /**
  * Represents the information stored in the database
  */
-export type StoredEventObject = RawLinkedEvent | RawEventObject;
+export type RawEventObject = RawLinkedEvent | RawRegularEventObject;
 
 export type FullPointOfContact = DisplayInternalPointOfContact | ExternalPointOfContact;
 
@@ -1088,7 +1104,7 @@ export type FullPointOfContact = DisplayInternalPointOfContact | ExternalPointOf
  * The meat of what this website is designed for; events can be signed up for
  * and hold information to facilitate easy information distribution
  */
-export interface EventObject extends RawEventObject {
+export interface RegularEventObject extends RawRegularEventObject {
 	/**
 	 * New events start with no attendance, but there can be procedurally
 	 * generated attendance on the client side to include internal POCs
@@ -1100,7 +1116,7 @@ export interface EventObject extends RawEventObject {
 	pointsOfContact: FullPointOfContact[];
 }
 
-export type FullEventObject = EventObject | (Omit<EventObject, 'type'> & RawLinkedEvent);
+export type EventObject = RegularEventObject | (Omit<RegularEventObject, 'type'> & RawLinkedEvent);
 
 /**
  * Used for transfer when creating a new event object, as it cannot know what

--- a/packages/common-lib/src/typings/types.ts
+++ b/packages/common-lib/src/typings/types.ts
@@ -436,6 +436,11 @@ export enum GroupTarget {
 	ACCOUNT,
 }
 
+export enum EventType {
+	REGULAR = 1,
+	LINKED,
+}
+
 // tslint:disable-next-line: no-namespace
 export namespace Permissions {
 	export enum FlightAssign {
@@ -1030,22 +1035,7 @@ export interface RawEventObject extends AccountIdentifiable, NewEventObject {
 	 * comment provided by a member
 	 */
 	debrief: DebriefItem[];
-	/**
-	 * If this is a linked event this will be present
-	 *
-	 * Linking events allows for one account to copy an event of another account
-	 * and receive updates and such
-	 */
-	sourceEvent?: null | {
-		/**
-		 * ID of the event it came from
-		 */
-		id: number;
-		/**
-		 * The account linked from
-		 */
-		accountID: string;
-	};
+
 	googleCalendarIds: {
 		/**
 		 * UUID of the Google Caldendar event on the main calendar
@@ -1060,7 +1050,37 @@ export interface RawEventObject extends AccountIdentifiable, NewEventObject {
 		 */
 		feeId?: null | string;
 	};
+
+	type: EventType.REGULAR;
 }
+
+export interface RawLinkedEvent extends AccountIdentifiable {
+	/**
+	 * ID of the link to the event
+	 */
+	id: number;
+	/**
+	 * Who it is that established this link
+	 */
+	linkAuthor: MemberReference;
+	/**
+	 * The event ID that this link references
+	 */
+	targetEventID: number;
+	/**
+	 * The account ID that the event this link references belongs to
+	 */
+	targetAccountID: string;
+	/**
+	 * Specify that this is a linked event
+	 */
+	type: EventType.LINKED;
+}
+
+/**
+ * Represents the information stored in the database
+ */
+export type StoredEventObject = RawLinkedEvent | RawEventObject;
 
 export type FullPointOfContact = DisplayInternalPointOfContact | ExternalPointOfContact;
 
@@ -1079,6 +1099,8 @@ export interface EventObject extends RawEventObject {
 	 */
 	pointsOfContact: FullPointOfContact[];
 }
+
+export type FullEventObject = EventObject | (Omit<EventObject, 'type'> & RawLinkedEvent);
 
 /**
  * Used for transfer when creating a new event object, as it cannot know what
@@ -3962,22 +3984,22 @@ export interface StoredMFASecret {
 
 export interface SignInLogData {
 	/**
-	 * 
+	 *
 	 */
 	memberRef: MemberReference;
 
 	/**
-	 * 
+	 *
 	 */
 	accountID: string;
 
 	/**
-	 * 
+	 *
 	 */
 	lastAccessTime: number;
 
 	/**
-	 * 
+	 *
 	 */
 	accessCount: number;
 }

--- a/packages/common-lib/src/typings/types.ts
+++ b/packages/common-lib/src/typings/types.ts
@@ -1098,6 +1098,10 @@ export interface RawLinkedEvent extends AccountIdentifiable {
  */
 export type RawEventObject = RawLinkedEvent | RawRegularEventObject;
 
+export type RawResolvedEventObject =
+	| RawRegularEventObject
+	| (Omit<RawRegularEventObject, 'type'> & RawLinkedEvent);
+
 export type FullPointOfContact = DisplayInternalPointOfContact | ExternalPointOfContact;
 
 /**

--- a/packages/server-common/src/Account.ts
+++ b/packages/server-common/src/Account.ts
@@ -50,6 +50,7 @@ import {
 	MaybeObj,
 	Member,
 	MemberReference,
+	MemberType,
 	memoize,
 	NewEventObject,
 	NHQ,
@@ -62,23 +63,23 @@ import {
 	RawCAPSquadronAccountObject,
 	RawCAPWingAccountObject,
 	RawEventObject,
+	RawRegularEventObject,
 	RawTeamObject,
 	ServerConfiguration,
 	ServerError,
 	statefulFunction,
 	StoredAccountMembership,
+	StoredProspectiveMemberObject,
 	stringifyMemberReference,
 	stripProp,
 	toReference,
 	User,
 	yieldObjAsync,
-	MemberType,
-	StoredProspectiveMemberObject,
 } from 'common-lib';
 import { copyFile } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
-import { addMemberToAttendanceFunc, createEventFunc, linkEventFunc } from './Event';
+import { addMemberToAttendanceFunc, createEventFunc, linkEvent } from './Event';
 import { createGoogleCalendarForEvent } from './GoogleUtils';
 import { setPermissionsForMemberInAccount } from './member/pam';
 import { CAP, resolveReference } from './Members';
@@ -238,6 +239,7 @@ export const createCAPEventAccountFunc = (now = Date.now) => (config: ServerConf
 		)
 		.tap(newAccount =>
 			createEventFunc(now)(config)(schema)(newAccount)(toReference(author))(newEvent)
+				.map<RawRegularEventObject>(event => event as RawRegularEventObject)
 				.tap(event =>
 					addMemberToAttendanceFunc(now)(schema)(newAccount)({
 						...event,
@@ -255,7 +257,7 @@ export const createCAPEventAccountFunc = (now = Date.now) => (config: ServerConf
 					}),
 				)
 				.tap(event =>
-					linkEventFunc(now)(config)(schema)(newAccount)(event)(toReference(author))(
+					linkEvent(config)(schema)(newAccount)(event)(toReference(author))(
 						parentAccount,
 					),
 				),

--- a/packages/server-common/src/Account.ts
+++ b/packages/server-common/src/Account.ts
@@ -271,6 +271,11 @@ export interface AccountGetter {
 	byOrgid: typeof getCAPAccountsForORGID;
 }
 
+export const getMemoizedAccountGetter = (schema: Schema): AccountGetter => ({
+	byId: always(memoize(getAccount(schema))),
+	byOrgid: always(memoize(getCAPAccountsForORGID(schema))),
+});
+
 export const getAccount = (schema: Schema) => (accountID: string) =>
 	asyncRight(
 		schema.getCollection<AccountObject>('Accounts'),

--- a/packages/server-common/src/GoogleUtils.ts
+++ b/packages/server-common/src/GoogleUtils.ts
@@ -25,8 +25,8 @@ import {
 	isOneOfSelected,
 	Maybe,
 	presentMultCheckboxReturn,
-	RawEventObject,
 	ServerConfiguration,
+	RawRegularEventObject,
 } from 'common-lib';
 import { calendar_v3, google } from 'googleapis';
 import { v4 as uuid } from 'uuid';
@@ -68,7 +68,10 @@ export const LodgingArrangments = [
 	'Individual tent',
 ];
 
-function buildEventDescription(config: ServerConfiguration, inEvent: RawEventObject): string {
+function buildEventDescription(
+	config: ServerConfiguration,
+	inEvent: RawRegularEventObject,
+): string {
 	// set status message
 	let status = 'invalid.  Please contact support@evmplus.org to report this.';
 	if (inEvent.status === EventStatus.TENTATIVE) {
@@ -166,7 +169,7 @@ function buildEventDescription(config: ServerConfiguration, inEvent: RawEventObj
 
 function buildDeadlineDescription(
 	config: ServerConfiguration,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	inStatement: string,
 ): string {
 	// set status message
@@ -253,7 +256,7 @@ export async function createGoogleCalendarForEvent(
 
 export async function createGoogleCalendarEvents(
 	schema: Schema,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	inAccount: AccountObject,
 	config: ServerConfiguration,
 ): Promise<[string | null, string | null, string | null]> {
@@ -285,10 +288,10 @@ export async function createGoogleCalendarEvents(
 
 export default async function updateGoogleCalendars(
 	schema: Schema,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	inAccount: AccountObject,
 	config: ServerConfiguration,
-) {
+): Promise<[string | null, string | null, string | null]> {
 	const privatekey = require(config.GOOGLE_KEYS_PATH + '/' + inAccount.id + '.json');
 	const jwtClient = new google.auth.JWT(
 		privatekey.client_email,
@@ -305,11 +308,11 @@ export default async function updateGoogleCalendars(
 		updateMainEvent(config, myCalendar, jwtClient, inEvent, inAccount.mainCalendarID),
 		updateRegEvent(config, myCalendar, jwtClient, inEvent, inAccount.mainCalendarID),
 		updateFeeEvent(config, myCalendar, jwtClient, inEvent, inAccount.mainCalendarID),
-	]) as Promise<[string, string | null, string | null]>;
+	]);
 }
 
 export async function removeGoogleCalendarEvents(
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	inAccount: AccountObject,
 	config: ServerConfiguration,
 ) {
@@ -423,7 +426,7 @@ async function deleteCalendarEvent(
 async function deleteCalendarEvents(
 	myCalendar: calendar_v3.Calendar,
 	jwtClient: JWTClient,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	ids: string,
 ) {
 	let errorFlag = false;
@@ -485,7 +488,7 @@ function getEventColor(inStatus: EventStatus) {
 	return eventColor;
 }
 
-function buildEvent(config: ServerConfiguration, inEvent: RawEventObject) {
+function buildEvent(config: ServerConfiguration, inEvent: RawRegularEventObject) {
 	const uniqueId = uuid().replace(/-/g, '');
 	let eventColor = getEventColor(inEvent.status);
 	if (inEvent.teamID !== 0) {
@@ -519,7 +522,7 @@ function buildEvent(config: ServerConfiguration, inEvent: RawEventObject) {
 
 function buildDeadline(
 	config: ServerConfiguration,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	inDate: number,
 	inString: string,
 ) {
@@ -554,7 +557,7 @@ async function updateFeeEvent(
 	config: ServerConfiguration,
 	myCalendar: calendar_v3.Calendar,
 	jwtClient: JWTClient,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	googleId: string,
 ) {
 	let response = { status: 200 };
@@ -612,7 +615,7 @@ async function updateRegEvent(
 	config: ServerConfiguration,
 	myCalendar: calendar_v3.Calendar,
 	jwtClient: JWTClient,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	googleId: string,
 ) {
 	let response = { status: 200 };
@@ -670,7 +673,7 @@ async function updateMainEvent(
 	config: ServerConfiguration,
 	myCalendar: calendar_v3.Calendar,
 	jwtClient: JWTClient,
-	inEvent: RawEventObject,
+	inEvent: RawRegularEventObject,
 	googleId: string,
 ) {
 	const event = buildEvent(config, inEvent);

--- a/packages/server-jest-config/jest-preset.js
+++ b/packages/server-jest-config/jest-preset.js
@@ -1,3 +1,22 @@
+/**
+ * Copyright (C) 2020 Andrew Rioux
+ *
+ * This file is part of EvMPlus.org.
+ *
+ * EvMPlus.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * EvMPlus.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EvMPlus.org.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 const { resolve } = require('path');
 
 module.exports = {

--- a/packages/server-jest-config/jest-preset.js
+++ b/packages/server-jest-config/jest-preset.js
@@ -1,0 +1,6 @@
+const { resolve } = require('path');
+
+module.exports = {
+	globalSetup: require(resolve(__dirname, 'setup.js')),
+	globalTeardown: require(resolve(__dirname, 'teardown.js')),
+};

--- a/packages/server-jest-config/setup.js
+++ b/packages/server-jest-config/setup.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2020 Andrew Rioux
+ *
+ * This file is part of EvMPlus.org.
+ *
+ * EvMPlus.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * EvMPlus.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EvMPlus.org.  If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/packages/server-jest-config/teardown.js
+++ b/packages/server-jest-config/teardown.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2020 Andrew Rioux
+ *
+ * This file is part of EvMPlus.org.
+ *
+ * EvMPlus.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * EvMPlus.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EvMPlus.org.  If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/packages/server/src/api/events/attendance/addattendance.ts
+++ b/packages/server/src/api/events/attendance/addattendance.ts
@@ -22,17 +22,17 @@ import {
 	always,
 	api,
 	applyCustomAttendanceFields,
-	AsyncEither,
 	asyncRight,
 	canSignUpForEvent,
-	effectiveManageEventPermissionForEvent,
 	Either,
 	errorGenerator,
 	EventObject,
+	hasBasicAttendanceManagementPermission,
 	isValidMemberReference,
 	Maybe,
+	MaybeObj,
 	NewAttendanceRecord,
-	Permissions,
+	RawTeamObject,
 	ServerError,
 	SessionType,
 	toReference,
@@ -49,9 +49,9 @@ import {
 
 const getRecord = (req: ServerAPIRequestParameter<api.events.attendance.Add>) => (
 	event: EventObject,
-) =>
+) => (teamMaybe: MaybeObj<RawTeamObject>) =>
 	(isValidMemberReference(req.body.memberID) &&
-	effectiveManageEventPermissionForEvent(req.member)(event) === Permissions.ManageEvent.FULL
+	hasBasicAttendanceManagementPermission(req.member)(event)(teamMaybe)
 		? resolveReference(req.mysqlx)(req.account)(req.body.memberID)
 		: asyncRight(req.member, errorGenerator('Could not get member'))
 	)
@@ -67,16 +67,15 @@ const getRecord = (req: ServerAPIRequestParameter<api.events.attendance.Add>) =>
 
 const addAttendance: ServerAPIEndpoint<api.events.attendance.Add> = req =>
 	getEvent(req.mysqlx)(req.account)(req.params.id)
+		.flatMap(getFullEventObject(req.mysqlx)(req.account)(Maybe.some(req.member)))
 		.flatMap(event =>
-			AsyncEither.All([
-				getFullEventObject(req.mysqlx)(req.account)(Maybe.some(req.member))(event),
-				event.teamID !== undefined && event.teamID !== null
-					? getTeam(req.mysqlx)(req.account)(event.teamID).map(Maybe.some)
-					: asyncRight(Maybe.none(), errorGenerator('Could not get team information')),
-			]),
+			(event.teamID !== undefined && event.teamID !== null
+				? getTeam(req.mysqlx)(req.account)(event.teamID).map(Maybe.some)
+				: asyncRight(Maybe.none(), errorGenerator('Could not get team information'))
+			).map(teamMaybe => [event, teamMaybe] as const),
 		)
 		.flatMap(([event, teamMaybe]) =>
-			getRecord(req)(event)
+			getRecord(req)(event)(teamMaybe)
 				.flatMap(rec =>
 					Either.map<ServerError, void, Required<NewAttendanceRecord>>(always(rec))(
 						Either.leftMap<string, ServerError, void>(err => ({

--- a/packages/server/src/api/events/attendance/getattendance.ts
+++ b/packages/server/src/api/events/attendance/getattendance.ts
@@ -26,12 +26,13 @@ import {
 	Permissions,
 	SessionType,
 } from 'common-lib';
-import { getAttendanceForEvent, getEvent, PAM } from 'server-common';
+import { ensureResolvedEvent, getAttendanceForEvent, getEvent, PAM } from 'server-common';
 
 export const func: ServerAPIEndpoint<api.events.attendance.GetAttendance> = PAM.RequireSessionType(
 	SessionType.REGULAR,
 )(req =>
 	getEvent(req.mysqlx)(req.account)(req.params.id)
+		.flatMap(ensureResolvedEvent(req.mysqlx))
 		.filter(
 			event =>
 				!event.privateAttendance ||

--- a/packages/server/src/api/events/debrief/adddebrief.ts
+++ b/packages/server/src/api/events/debrief/adddebrief.ts
@@ -18,7 +18,15 @@
  */
 
 import { ServerAPIEndpoint } from 'auto-client-api';
-import { always, api, get, RawEventObject, SessionType, toReference } from 'common-lib';
+import {
+	always,
+	api,
+	EventType,
+	get,
+	RawRegularEventObject,
+	SessionType,
+	toReference,
+} from 'common-lib';
 import { getEvent, PAM, saveEventFunc } from 'server-common';
 
 export const func: (now?: () => number) => ServerAPIEndpoint<api.events.debrief.Add> = (
@@ -26,20 +34,27 @@ export const func: (now?: () => number) => ServerAPIEndpoint<api.events.debrief.
 ) =>
 	PAM.RequireSessionType(SessionType.REGULAR)(req =>
 		getEvent(req.mysqlx)(req.account)(req.params.id)
-			.map<[RawEventObject, RawEventObject]>(oldEvent => [
-				oldEvent,
-				{
-					...oldEvent,
-					debrief: [
-						...oldEvent.debrief,
-						{
-							debriefText: req.body.debriefText,
-							memberRef: toReference(req.member),
-							timeSubmitted: now(),
-						},
-					],
-				},
-			])
+			.filter(event => event.type === EventType.REGULAR, {
+				type: 'OTHER',
+				code: 403,
+				message: 'You cannot modify debrief items of a linked event',
+			})
+			.map<[RawRegularEventObject, RawRegularEventObject]>(
+				(oldEvent: RawRegularEventObject) => [
+					oldEvent,
+					{
+						...oldEvent,
+						debrief: [
+							...oldEvent.debrief,
+							{
+								debriefText: req.body.debriefText,
+								memberRef: toReference(req.member),
+								timeSubmitted: now(),
+							},
+						],
+					},
+				],
+			)
 			.flatMap(([oldEvent, newEvent]) =>
 				saveEventFunc(now)(req.configuration)(req.mysqlx)(req.account)(oldEvent)(
 					newEvent,

--- a/packages/server/src/api/events/events/linkevent.ts
+++ b/packages/server/src/api/events/events/linkevent.ts
@@ -28,6 +28,7 @@ import {
 	EventType,
 	hasBasicEventPermissions,
 	RawRegularEventObject,
+	RawResolvedEventObject,
 	toReference,
 	User,
 } from 'common-lib';
@@ -64,6 +65,13 @@ export const func: ServerAPIEndpoint<api.events.events.Link> = req =>
 					linkEvent(req.configuration)(req.mysqlx)(req.account)(event)(
 						toReference(req.member),
 					),
+				)
+				.map(
+					linkedEvent =>
+						({
+							...event,
+							...linkedEvent,
+						} as RawResolvedEventObject),
 				),
 		);
 

--- a/packages/server/src/api/events/events/linkevent.ts
+++ b/packages/server/src/api/events/events/linkevent.ts
@@ -19,12 +19,15 @@
 
 import { ServerAPIEndpoint } from 'auto-client-api';
 import {
+	AccountObject,
 	always,
 	api,
 	AsyncEither,
 	asyncRight,
 	errorGenerator,
+	EventType,
 	hasBasicEventPermissions,
+	RawRegularEventObject,
 	toReference,
 	User,
 } from 'common-lib';
@@ -34,28 +37,34 @@ export const func: ServerAPIEndpoint<api.events.events.Link> = req =>
 	AsyncEither.All([
 		getEvent(req.mysqlx)(req.account)(req.params.eventid),
 		getAccount(req.mysqlx)(req.params.targetaccount),
-	]).flatMap(([event, targetAccount]) =>
-		asyncRight(
-			PAM.getPermissionsForMemberInAccountDefault(
-				req.mysqlx,
-				toReference(req.member),
-				targetAccount,
-			),
-			errorGenerator('Could not get permissions for account'),
-		)
-			.map<User>(permissions => ({ ...req.member, permissions }))
-			.filter(hasBasicEventPermissions, {
-				type: 'OTHER',
-				code: 403,
-				message:
-					'Member does not have permission to perform this action in the specified account',
-			})
-			.map(always(targetAccount))
-			.flatMap(
-				linkEvent(req.configuration)(req.mysqlx)(req.account)(event)(
+	])
+		.filter(([event]) => event.type === EventType.REGULAR, {
+			type: 'OTHER',
+			code: 400,
+			message: 'You cannot link to a linked event',
+		})
+		.flatMap(([event, targetAccount]: [RawRegularEventObject, AccountObject]) =>
+			asyncRight(
+				PAM.getPermissionsForMemberInAccountDefault(
+					req.mysqlx,
 					toReference(req.member),
+					targetAccount,
 				),
-			),
-	);
+				errorGenerator('Could not get permissions for account'),
+			)
+				.map<User>(permissions => ({ ...req.member, permissions }))
+				.filter(hasBasicEventPermissions, {
+					type: 'OTHER',
+					code: 403,
+					message:
+						'Member does not have permission to perform this action in the specified account',
+				})
+				.map(always(targetAccount))
+				.flatMap(
+					linkEvent(req.configuration)(req.mysqlx)(req.account)(event)(
+						toReference(req.member),
+					),
+				),
+		);
 
 export default func;

--- a/packages/server/src/api/events/events/setevent.ts
+++ b/packages/server/src/api/events/events/setevent.ts
@@ -22,10 +22,11 @@ import {
 	always,
 	api,
 	canManageEvent,
+	EventType,
 	Maybe,
 	NewEventObject,
 	Permissions,
-	RawEventObject,
+	RawRegularEventObject,
 	SessionType,
 	Validator,
 } from 'common-lib';
@@ -42,21 +43,28 @@ export const func: (now?: () => number) => ServerAPIEndpoint<api.events.events.S
 	PAM.RequireSessionType(SessionType.REGULAR)(request =>
 		validateRequest(partialEventValidator)(request).flatMap(req =>
 			getEvent(req.mysqlx)(req.account)(req.params.id)
+				.filter(event => event.type === EventType.REGULAR, {
+					type: 'OTHER',
+					code: 400,
+					message: 'You cannot modify a linked event',
+				})
 				.filter(canManageEvent(Permissions.ManageEvent.ADDDRAFTEVENTS)(req.member), {
 					type: 'OTHER',
 					code: 403,
 					message: 'Member does not have permission to perform that action',
 				})
-				.map<[RawEventObject, RawEventObject]>(event => [
-					{
-						...event,
-						...req.body,
-						status: canManageEvent(Permissions.ManageEvent.FULL)(req.member)(event)
-							? req.body.status ?? event.status
-							: event.status,
-					},
-					event,
-				])
+				.map<[RawRegularEventObject, RawRegularEventObject]>(
+					(event: RawRegularEventObject) => [
+						{
+							...event,
+							...req.body,
+							status: canManageEvent(Permissions.ManageEvent.FULL)(req.member)(event)
+								? req.body.status ?? event.status
+								: event.status,
+						},
+						event,
+					],
+				)
 				.flatMap(([newEvent, oldEvent]) =>
 					saveEventFunc(now)(req.configuration)(req.mysqlx)(req.account)(oldEvent)(
 						newEvent,

--- a/packages/server/src/api/member/session/setscanaddsession.ts
+++ b/packages/server/src/api/member/session/setscanaddsession.ts
@@ -19,7 +19,7 @@
 
 import { ServerAPIEndpoint } from 'auto-client-api';
 import { api, canManageEvent, Permissions, SessionType } from 'common-lib';
-import { getEvent, PAM } from 'server-common';
+import { ensureResolvedEvent, getEvent, PAM } from 'server-common';
 import { updateSession } from 'server-common/dist/member/pam';
 
 export const func: (
@@ -32,6 +32,7 @@ export const func: (
 				code: 403,
 				message: 'You do not have permission to manage this event',
 			})
+			.flatMap(ensureResolvedEvent(req.mysqlx))
 			.filter(event => event.meetDateTime > now(), {
 				type: 'OTHER',
 				code: 403,

--- a/packages/util-cli/src/convert.ts
+++ b/packages/util-cli/src/convert.ts
@@ -26,12 +26,15 @@ import {
 	AttendanceRecord,
 	AttendanceStatus,
 	CAPEventMemberPermissions,
+	CAPExtraMemberInformation,
 	CAPGroupMemberPermissions,
 	CAPRegionMemberPermissions,
 	CAPSquadronMemberPermissions,
 	CAPWingMemberPermissions,
 	CustomAttendanceFieldValue,
+	DiscordServerInformation,
 	Either,
+	errorGenerator,
 	ExternalPointOfContact,
 	identity,
 	InternalPointOfContact,
@@ -40,17 +43,14 @@ import {
 	MemberReference,
 	Permissions,
 	PointOfContactType,
-	RawEventObject,
+	RawRegularEventObject,
 	RawServerConfiguration,
 	RawTeamObject,
+	RegistryValues,
 	StoredMemberPermissions,
+	stringifyMemberReference,
 	stripProp,
 	Validator,
-	errorGenerator,
-	CAPExtraMemberInformation,
-	stringifyMemberReference,
-	RegistryValues,
-	DiscordServerInformation,
 } from 'common-lib';
 import 'dotenv/config';
 import { confFromRaw, generateResults, getAccount } from 'server-common';
@@ -217,8 +217,8 @@ process.on('unhandledRejection', up => {
 	);
 	console.log('Moved teams.\n');
 
-	const v5eventsCollection = v5schema.getCollection<RawEventObject>('Events');
-	const v6eventsCollection = v6schema.getCollection<RawEventObject>('Events');
+	const v5eventsCollection = v5schema.getCollection<RawRegularEventObject>('Events');
+	const v6eventsCollection = v6schema.getCollection<RawRegularEventObject>('Events');
 
 	const correctPOC = (
 		poc:
@@ -242,7 +242,7 @@ process.on('unhandledRejection', up => {
 
 	console.log('Moving events...');
 	console.log(
-		await moveFromOneToOther<RawEventObject>(event => ({
+		await moveFromOneToOther<RawRegularEventObject>(event => ({
 			...event,
 			pointsOfContact: event.pointsOfContact.map(correctPOC),
 		}))(v5eventsCollection, v6eventsCollection),


### PR DESCRIPTION
Events are now either links or event objects, not both. Attendance is stored at the central event
object. All views of an event for a linked event will pull the target event information and merge
the two. Attendance will pull the target event, but will filter based off of the account. No one has
permissions to modify the links themselves, nor the data of the central event. Permissions for
attendance are based off of the local event and check to make sure the record is viewable from the
local account perspective.

fix #11 