### PR TITLE
feat(client): changed display of debrief link to be associated with d…

### DIFF
--- a/packages/client/src/pages/events/EventViewer.tsx
+++ b/packages/client/src/pages/events/EventViewer.tsx
@@ -783,7 +783,7 @@ export class EventViewer extends Page<EventViewerProps, EventViewerState> {
 						)}
 						<br />
 						{member &&
-						(event.status === EventStatus.COMPLETE ||
+						(event.pickupDateTime < new Date().getTime() ||
 							event.status === EventStatus.CANCELLED) ? (
 							<DialogueButtonForm<{
 								publicView: boolean;


### PR DESCRIPTION
…rop off time compared with time

affects: client

if event display is requested after the pickup time (or if the event status is cancelled) then the
debrief link will be displayed on event viewer.

ISSUES CLOSED: #220