### PR TITLE
fix(client): change default configuration

### DIFF
--- a/packages/client/src/pages/team/TeamEmail.tsx
+++ b/packages/client/src/pages/team/TeamEmail.tsx
@@ -214,7 +214,7 @@ export default class TeamEmailList extends Page<PageProps<{ id: string }>, Email
 		sortFunction: SortFunction.LASTNAME,
 		visibleItems: [],
 		displayAdvanced: false,
-		addParentEmails: false,
+		addParentEmails: true,
 		filterValues: {
 			memberFilter: MemberList.ALL,
 			nameInput: '',


### PR DESCRIPTION
affects: client

Set the checkbox for sending emails to parents to be true by default.

ISSUES CLOSED: #136