### PR TITLE
Fix login process

### DIFF
--- a/packages/client/src/components/form-inputs/PasswordForm.tsx
+++ b/packages/client/src/components/form-inputs/PasswordForm.tsx
@@ -111,6 +111,15 @@ export default class PasswordForm extends React.Component<
 			<TextBox>
 				Please enter and confirm a password.
 				<br />
+				<br />
+				New update effective January 1st, 2024: All passwords must be at least 11 characters
+				in length. To read more about this change, please visit{' '}
+				<a href="https://github.com/cap-md089/evmplus-guides/wiki/Password-policy">
+					our user guide
+				</a>
+				.
+				<br />
+				<br />
 				Passwords must meet the following requirements:
 				<ul>
 					<li className={getClassFromShowLevel(this.state.showLengthError)}>

--- a/packages/client/src/components/form-inputs/PasswordForm.tsx
+++ b/packages/client/src/components/form-inputs/PasswordForm.tsx
@@ -61,6 +61,10 @@ const formValidator = {
 	confirmPassword: passwordValidator,
 };
 
+export interface PasswordFormProps extends InputProps<string | null> {
+	passwordInHistory: boolean;
+}
+
 /**
  * A password form
  *
@@ -110,7 +114,7 @@ export default class PasswordForm extends React.Component<
 				Passwords must meet the following requirements:
 				<ul>
 					<li className={getClassFromShowLevel(this.state.showLengthError)}>
-						Length of at least 8 characters
+						Length of at least 11 characters
 					</li>
 					<li
 						className={getClassFromShowLevel(
@@ -138,8 +142,8 @@ export default class PasswordForm extends React.Component<
 					</li>
 				</ul>
 				* A special character is a space character or one of the following symbols:
-				<br />^ ! @ # $ % ^ &amp; * ( ) {'{'} {'}'} _ + - = {'<'} {'>'} , . ? / [ ] \ | ; '
-				"
+				<br />^ ! @ # $ % ^ &amp; * ( ) {'{'} {'}'} _ + - = &lt; &gt; , . ? / [ ] \ | ;
+				&apos; &quot;
 				<br />
 				<span className={getClassFromShowLevel(this.state.showMatchError)}>
 					Passwords must also match
@@ -213,7 +217,7 @@ export default class PasswordForm extends React.Component<
 			hasError = true;
 		}
 
-		if (fields.password.length >= 8) {
+		if (fields.password.length >= 11) {
 			update.showLengthError = ShowLevel.SHOWGOOD;
 		} else {
 			hasError = true;

--- a/packages/client/src/pages/account/CreateProspectiveMember.tsx
+++ b/packages/client/src/pages/account/CreateProspectiveMember.tsx
@@ -359,7 +359,10 @@ export default class CreateProspectiveMember extends Page<PageProps, CreateAccou
 				seniorMember: !!form.seniorMember,
 			};
 
-			const password: CAPProspectiveMemberPasswordCreation = form.password;
+			const password: CAPProspectiveMemberPasswordCreation =
+				form.password.type !== CAPProspectiveMemberPasswordCreationType.EMAILLINK
+					? { ...form.password, username: form.password.username.trim() }
+					: form.password;
 
 			await fetchApi.member.account.capprospective
 				.requestProspectiveAccount(

--- a/packages/client/src/pages/account/FinishSignup.tsx
+++ b/packages/client/src/pages/account/FinishSignup.tsx
@@ -51,7 +51,7 @@ export default class FinishSignup extends Page<PageProps<{ token: string }>, Fin
 	public componentDidMount(): void {
 		this.props.deleteReduxState();
 	}
-		
+
 	public render = (): JSX.Element => (
 		<SimpleForm<FormValues>
 			disableOnInvalid={true}
@@ -116,7 +116,7 @@ export default class FinishSignup extends Page<PageProps<{ token: string }>, Fin
 
 		const fetchResult = await fetchApi.member.account.finishAccountSetup(
 			{},
-			{ token, username, password },
+			{ token, username: username.trim(), password },
 		);
 
 		if (Either.isLeft(fetchResult)) {

--- a/packages/client/src/pages/account/RequestPasswordReset.tsx
+++ b/packages/client/src/pages/account/RequestPasswordReset.tsx
@@ -84,6 +84,8 @@ export default class RequestPasswordResetForm extends Page<PageProps, RequestPas
 						<p>
 							Password reset request succesful. Please check your inbox for a password
 							reset link. The email may take up to 5 minutes to appear in your inbox.
+							If nothing shows up after 5 minutes, please double check the username
+							provided
 						</p>
 						<p>
 							If the email is not received in your inbox, please check your Spam or

--- a/packages/client/src/pages/account/RequestPasswordReset.tsx
+++ b/packages/client/src/pages/account/RequestPasswordReset.tsx
@@ -56,7 +56,7 @@ export default class RequestPasswordResetForm extends Page<PageProps, RequestPas
 	public componentDidMount(): void {
 		this.props.deleteReduxState();
 	}
-		
+
 	public render = (): JSX.Element => (
 		<SimpleForm<RequestPasswordResetFormValues>
 			values={this.state.form}
@@ -68,7 +68,7 @@ export default class RequestPasswordResetForm extends Page<PageProps, RequestPas
 				username: val => val?.length > 0,
 			}}
 			submitInfo={{
-				disabled: this.state.tryingSubmit,
+				disabled: this.state.tryingSubmit || this.state.success,
 				text: 'Request password reset',
 			}}
 		>
@@ -80,14 +80,16 @@ export default class RequestPasswordResetForm extends Page<PageProps, RequestPas
 			) : null}
 			{this.state.success ? (
 				<TextBox>
-					<p>
-						Password reset request succesful. Please check your inbox for a password
-						reset link.
-					</p>
-					<p>
-						If the email is not received in your inbox, please check your Spam or Junk
-						folder for the message
-					</p>
+					<div className="banner">
+						<p>
+							Password reset request succesful. Please check your inbox for a password
+							reset link. The email may take up to 5 minutes to appear in your inbox.
+						</p>
+						<p>
+							If the email is not received in your inbox, please check your Spam or
+							Junk folder for the message
+						</p>
+					</div>
 				</TextBox>
 			) : null}
 

--- a/packages/client/src/pages/account/RequestPasswordReset.tsx
+++ b/packages/client/src/pages/account/RequestPasswordReset.tsx
@@ -138,7 +138,7 @@ export default class RequestPasswordResetForm extends Page<PageProps, RequestPas
 		const result = await fetchApi.member.account.passwordResetRequest(
 			{},
 			{
-				username: form.username,
+				username: form.username.trim(),
 				captchaToken: form.captchaToken,
 			},
 		);

--- a/packages/client/src/pages/account/RequestUsername.tsx
+++ b/packages/client/src/pages/account/RequestUsername.tsx
@@ -56,7 +56,7 @@ export default class RequestUsernameForm extends Page<PageProps, RequestUsername
 	public componentDidMount(): void {
 		this.props.deleteReduxState();
 	}
-		
+
 	public render = (): JSX.Element => (
 		<SimpleForm<RequestUsernameFormValues>
 			values={this.state.form}
@@ -68,7 +68,7 @@ export default class RequestUsernameForm extends Page<PageProps, RequestUsername
 				capid: val => val !== null && val >= 100000,
 			}}
 			submitInfo={{
-				disabled: this.state.tryingSubmit,
+				disabled: this.state.tryingSubmit || this.state.success,
 				text: 'Request login',
 			}}
 		>
@@ -80,14 +80,17 @@ export default class RequestUsernameForm extends Page<PageProps, RequestUsername
 			) : null}
 			{this.state.success ? (
 				<TextBox>
-					<p>
-						Login request successful. Please check the email associated with the CAP ID
-						entered for an email with your CAP account.
-					</p>
-					<p>
-						If the email is not received in your inbox, please check your Spam or Junk
-						folder for the message
-					</p>
+					<div className="banner">
+						<p>
+							Login request successful. Please check the email associated with the CAP
+							ID entered for an email with your CAP account. This email may take up to
+							5 minutes to appear in your inbox.
+						</p>
+						<p>
+							If the email is not received in your inbox, please check your Spam or
+							Junk folder for the message
+						</p>
+					</div>
 				</TextBox>
 			) : null}
 

--- a/packages/client/src/pages/account/Signin.tsx
+++ b/packages/client/src/pages/account/Signin.tsx
@@ -156,7 +156,7 @@ export const RegularSignin: React.FC<SigninPageProps> = ({ state, authorizeUser,
 			.signin(
 				{},
 				{
-					username: state.signinFormValues.username,
+					username: state.signinFormValues.username.trim(),
 					password: state.signinFormValues.password,
 					token: {
 						type: SigninTokenType.RECAPTCHA,

--- a/packages/client/src/pages/account/Signup.tsx
+++ b/packages/client/src/pages/account/Signup.tsx
@@ -58,7 +58,7 @@ export default class Signup extends Page<PageProps, SignupFormState> {
 	public componentDidMount(): void {
 		this.props.deleteReduxState();
 	}
-		
+
 	public constructor(props: PageProps) {
 		super(props);
 
@@ -99,8 +99,10 @@ export default class Signup extends Page<PageProps, SignupFormState> {
 			) : null}
 			{this.state.success ? (
 				<TextBox>
-					Account request successful. Check your inbox and spam folder for a link to
-					finish creating your account
+					<div className="banner">
+						Account request successful. Check your inbox and spam folder for a link to
+						finish creating your account
+					</div>
 				</TextBox>
 			) : null}
 

--- a/packages/common-lib/src/lib/passwordComplexity.ts
+++ b/packages/common-lib/src/lib/passwordComplexity.ts
@@ -24,7 +24,7 @@
  */
 export const passwordMeetsRequirements = (password: string): boolean =>
 	password.length > 32 ||
-	(password.length >= 8 &&
+	(password.length >= 11 &&
 		// lowercase letter
 		!!password.match(/[a-z]/g) &&
 		// uppercase letter

--- a/packages/server-common/src/member/pam/Password.ts
+++ b/packages/server-common/src/member/pam/Password.ts
@@ -263,7 +263,10 @@ export const checkIfPasswordValid = async (
 
 	const passwordExpireDate = userInfo.passwordHistory[0].created + PASSWORD_MAX_AGE;
 	if (passwordExpireDate < Date.now()) {
-		return PasswordResult.VALID_EXPIRED;
+		if (passwordExpireDate < 1706763600000 + PASSWORD_MAX_AGE) {
+			return PasswordResult.VALID_EXPIRED;
+		}
+		return PasswordResult.VALID;
 	}
 
 	return PasswordResult.VALID;

--- a/packages/server/src/api/member/account/finishpasswordreset.ts
+++ b/packages/server/src/api/member/account/finishpasswordreset.ts
@@ -17,7 +17,7 @@
  * along with EvMPlus.org.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { api, get, Maybe } from 'common-lib';
+import { always, api, get, Maybe } from 'common-lib';
 import { Backends, getCombinedPAMBackend, PAM, withBackends } from 'server-common';
 import { Endpoint } from '../../..';
 
@@ -27,7 +27,9 @@ export const func: Endpoint<
 > = backend => req =>
 	backend
 		.validatePasswordResetToken(req.body.token)
-		.tap(username => backend.addPasswordForUser([username, req.body.newPassword]))
+		.flatMap(username =>
+			backend.addPasswordForUser([username, req.body.newPassword]).map(always(username)),
+		)
 		.tap(() => backend.removePasswordValidationToken(req.body.token))
 		.flatMap(backend.getUserInformationForUser)
 		.filter(Maybe.isSome, {


### PR DESCRIPTION
Improved the login process by:

1. Adding banners and disabling buttons to prevent multiple successive username and password reset requests - page reload between requests now required
2. Trimming usernames everywhere to handle people adding spaces to their names
3. Made password reset error out when people reuse old passwords instead of silently ignoring the error
4. Upped the password minimum password length from 8 to 11...
5. ...but also removed max password age