### PR TITLE
fix: fixed Cadet Status Report SQR 60-1

### DIFF
--- a/packages/client/src/pages/admin/pluggables/Reports.tsx
+++ b/packages/client/src/pages/admin/pluggables/Reports.tsx
@@ -331,10 +331,10 @@ export const ReportsWidget = withFetchApi(
 			const wb = XLSX.utils.book_new();
 
 			let wsName = 'UnitInfo';
-			const wsDataEvent = spreadsheets.sqr6020XL();
+			const wsDataEvent = spreadsheets.sqr601XL();
 			let ws = XLSX.utils.aoa_to_sheet(wsDataEvent);
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			let sheet = spreadsheets.Formatsqr6020XL(ws);
+			let sheet = spreadsheets.Formatsqr601XL(ws);
 			XLSX.utils.book_append_sheet(wb, sheet, wsName);
 
 			wsName = 'CadetInfo';
@@ -344,7 +344,7 @@ export const ReportsWidget = withFetchApi(
 				// this.props.registry,
 			);
 			ws = XLSX.utils.aoa_to_sheet(wsDataAttendance);
-			sheet = spreadsheets.Formatsqr6020MembersXL(ws, widths, wsDataAttendance.length);
+			sheet = spreadsheets.Formatsqr601MembersXL(ws, widths, wsDataAttendance.length);
 			XLSX.utils.book_append_sheet(wb, sheet, wsName);
 
 			const now = new Date();

--- a/packages/common-lib/src/renderers/spreadsheets/sqr601.ts
+++ b/packages/common-lib/src/renderers/spreadsheets/sqr601.ts
@@ -53,9 +53,9 @@ const getHFZExpire = (reqs: CadetPromotionStatus): string =>
 	pipe(
 		get<CadetPromotionStatus, 'HFZRecord'>('HFZRecord'),
 		Maybe.filter(({ IsPassed }) => IsPassed || reqs.CurrentCadetAchv.CadetAchvID < 4),
-		Maybe.map(({ DateTaken }) => DateTaken.substr(0, 10)),
-		Maybe.map(s => +new Date(s) + 182 * 24 * 60 * 60 * 1000),
-		Maybe.map(s => new Date(s).toLocaleDateString('en-US')),
+		Maybe.map(({ DateTaken, IsPassed }) => [DateTaken.substr(0, 10), IsPassed] as const),
+		Maybe.map(([s, f]) => [+new Date(s) + 182 * 24 * 60 * 60 * 1000, f] as const),
+		Maybe.map(([s, f]) => new Date(s).toLocaleDateString('en-US') + (!f ? ' F' : '')),
 		Maybe.orSome(''),
 	)(reqs);
 


### PR DESCRIPTION
pdf version of report had "F" flag if cadet did not pass last HFZ attempt, but xls version of report did not.  Added 'F" flag to xls report.

ISSUES CLOSED: #385