### PR TITLE
Grioux add member search permission

### DIFF
--- a/packages/client/src/components/form-inputs/PermissionsEdit.tsx
+++ b/packages/client/src/components/form-inputs/PermissionsEdit.tsx
@@ -405,6 +405,15 @@ export default class PermissionsEdit extends React.Component<
 				values={[Permissions.RegistryEdit.NO, Permissions.RegistryEdit.YES]}
 				defaultValue={Permissions.RegistryEdit.NO}
 			/>
+
+			<Label key="41">Member Search</Label>
+			<EnumSelect<Permissions.MemberSearch>
+				key="42"
+				name="MemberSearch"
+				labels={['No', 'Yes']}
+				values={[Permissions.MemberSearch.NO , Permissions.MemberSearch.YES]}
+				defaultValue={Permissions.MemberSearch.YES}
+			/>
 		</FormBlock>
 	);
 
@@ -758,6 +767,14 @@ export default class PermissionsEdit extends React.Component<
 				values={[Permissions.RegistryEdit.NO, Permissions.RegistryEdit.YES]}
 				defaultValue={Permissions.RegistryEdit.NO}
 			/>
+			<Label key="41">Member Search</Label>
+			<EnumSelect<Permissions.MemberSearch>
+				key="42"
+				name="MemberSearch"
+				labels={['No', 'Yes']}
+				values={[Permissions.MemberSearch.NO , Permissions.MemberSearch.YES]}
+				defaultValue={Permissions.MemberSearch.YES}
+			/>
 		</FormBlock>
 	);
 
@@ -930,6 +947,14 @@ export default class PermissionsEdit extends React.Component<
 				values={[Permissions.CreateEventAccount.NO, Permissions.CreateEventAccount.YES]}
 				defaultValue={Permissions.CreateEventAccount.NO}
 			/>
+			<Label key="43">Member Search</Label>
+			<EnumSelect<Permissions.MemberSearch>
+				key="44"
+				name="MemberSearch"
+				labels={['No', 'Yes']}
+				values={[Permissions.MemberSearch.NO , Permissions.MemberSearch.YES]}
+				defaultValue={Permissions.MemberSearch.YES}
+			/>
 		</FormBlock>
 	);
 
@@ -1101,6 +1126,14 @@ export default class PermissionsEdit extends React.Component<
 				labels={['No', 'Yes']}
 				values={[Permissions.CreateEventAccount.NO, Permissions.CreateEventAccount.YES]}
 				defaultValue={Permissions.CreateEventAccount.NO}
+			/>
+			<Label key="43">Member Search</Label>
+			<EnumSelect<Permissions.MemberSearch>
+				key="44"
+				name="MemberSearch"
+				labels={['No', 'Yes']}
+				values={[Permissions.MemberSearch.NO , Permissions.MemberSearch.YES]}
+				defaultValue={Permissions.MemberSearch.YES}
 			/>
 		</FormBlock>
 	);

--- a/packages/client/src/pages/admin/pluggables/FindMember.tsx
+++ b/packages/client/src/pages/admin/pluggables/FindMember.tsx
@@ -28,6 +28,7 @@ import {
 	Either,
 	EitherObj,
 	getFullMemberName,
+	hasPermission,
 	HTTPError,
 	identity,
 	isRioux,
@@ -464,7 +465,8 @@ export function configureStore(fetchApi: TFetchAPI): Store<MemberSearchState, Me
 }
 
 export const shouldRenderMemberSearchWidget = ({ member }: PageProps): boolean =>
-	!!member && ((member.seniorMember && member.dutyPositions.length > 0) || isRioux(member));
+	!!member && ((member.seniorMember && member.dutyPositions.length > 0) || isRioux(member)
+		|| hasPermission('MemberSearch')(Permissions.MemberSearch.YES)(props.member));
 
 export interface RequiredMember extends PageProps, FetchAPIProps {
 	member: ClientUser;

--- a/packages/client/src/pages/admin/pluggables/FindMember.tsx
+++ b/packages/client/src/pages/admin/pluggables/FindMember.tsx
@@ -34,6 +34,7 @@ import {
 	isRioux,
 	Maybe,
 	NHQ,
+	Permissions,
 	pipe,
 	ShortNHQDutyPosition,
 	stringifyMemberReference
@@ -464,8 +465,8 @@ export function configureStore(fetchApi: TFetchAPI): Store<MemberSearchState, Me
 	return store;
 }
 
-export const shouldRenderMemberSearchWidget = ({ member }: PageProps): boolean =>
-	!!member && ((member.seniorMember && member.dutyPositions.length > 0) || isRioux(member)
+export const shouldRenderMemberSearchWidget = (props: PageProps): boolean =>
+	!!props.member && ((props.member.seniorMember && props.member.dutyPositions.length > 0) || isRioux(props.member)
 		|| hasPermission('MemberSearch')(Permissions.MemberSearch.YES)(props.member));
 
 export interface RequiredMember extends PageProps, FetchAPIProps {

--- a/packages/common-lib/src/lib/Permissions.ts
+++ b/packages/common-lib/src/lib/Permissions.ts
@@ -36,6 +36,7 @@ const CAPEventDefault: Readonly<CAPEventMemberPermissions> = {
 	MusterSheet: Permissions.MusterSheet.NO,
 	AssignTasks: Permissions.AssignTasks.NO,
 	AdministerPT: Permissions.AdministerPT.NO,
+	MemberSearch: Permissions.MemberSearch.NO,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.NONE,
@@ -63,6 +64,7 @@ const CAPEventStaff: Readonly<CAPEventMemberPermissions> = {
 	MusterSheet: Permissions.MusterSheet.YES,
 	AssignTasks: Permissions.AssignTasks.YES,
 	AdministerPT: Permissions.AdministerPT.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.ADDDRAFTEVENTS,
@@ -90,6 +92,7 @@ const CAPEventManager: Readonly<CAPEventMemberPermissions> = {
 	MusterSheet: Permissions.MusterSheet.YES,
 	AssignTasks: Permissions.AssignTasks.YES,
 	AdministerPT: Permissions.AdministerPT.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -117,6 +120,7 @@ const CAPEventAdmin: Readonly<CAPEventMemberPermissions> = {
 	MusterSheet: Permissions.MusterSheet.YES,
 	AssignTasks: Permissions.AssignTasks.YES,
 	AdministerPT: Permissions.AdministerPT.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -146,6 +150,7 @@ const CAPSquadronDefault: Readonly<CAPSquadronMemberPermissions> = {
 	PromotionManagement: Permissions.PromotionManagement.NONE,
 	AssignTasks: Permissions.AssignTasks.NO,
 	AdministerPT: Permissions.AdministerPT.NO,
+	MemberSearch: Permissions.MemberSearch.NO,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.NONE,
@@ -176,6 +181,7 @@ const CAPSquadronStaff: Readonly<CAPSquadronMemberPermissions> = {
 	PromotionManagement: Permissions.PromotionManagement.FULL,
 	AssignTasks: Permissions.AssignTasks.YES,
 	AdministerPT: Permissions.AdministerPT.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.ADDDRAFTEVENTS,
@@ -206,6 +212,7 @@ const CAPSquadronManager: Readonly<CAPSquadronMemberPermissions> = {
 	PromotionManagement: Permissions.PromotionManagement.FULL,
 	AssignTasks: Permissions.AssignTasks.YES,
 	AdministerPT: Permissions.AdministerPT.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -236,6 +243,7 @@ const CAPSquadronAdmin: Readonly<CAPSquadronMemberPermissions> = {
 	PromotionManagement: Permissions.PromotionManagement.FULL,
 	AssignTasks: Permissions.AssignTasks.YES,
 	AdministerPT: Permissions.AdministerPT.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -261,6 +269,7 @@ const CAPGroupDefault: Readonly<CAPGroupMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.NO,
+	MemberSearch: Permissions.MemberSearch.NO,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.NONE,
@@ -285,6 +294,7 @@ const CAPGroupStaff: Readonly<CAPGroupMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.ADDDRAFTEVENTS,
@@ -309,6 +319,7 @@ const CAPGroupManager: Readonly<CAPGroupMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -333,6 +344,7 @@ const CAPGroupAdmin: Readonly<CAPGroupMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -357,6 +369,7 @@ const CAPWingDefault: Readonly<CAPWingMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.NO,
+	MemberSearch: Permissions.MemberSearch.NO,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.NONE,
@@ -382,6 +395,7 @@ const CAPWingStaff: Readonly<CAPWingMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.ADDDRAFTEVENTS,
@@ -407,6 +421,7 @@ const CAPWingManager: Readonly<CAPWingMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -432,6 +447,7 @@ const CAPWingAdmin: Readonly<CAPWingMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -457,6 +473,7 @@ const CAPRegionDefault: Readonly<CAPRegionMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.NO,
+	MemberSearch: Permissions.MemberSearch.NO,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.NONE,
@@ -482,6 +499,7 @@ const CAPRegionStaff: Readonly<CAPRegionMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.ADDDRAFTEVENTS,
@@ -507,6 +525,7 @@ const CAPRegionManager: Readonly<CAPRegionMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,
@@ -532,6 +551,7 @@ const CAPRegionAdmin: Readonly<CAPRegionMemberPermissions> = {
 
 	// Staff privileges
 	AssignTasks: Permissions.AssignTasks.YES,
+	MemberSearch: Permissions.MemberSearch.YES,
 
 	// Manager privileges
 	ManageEvent: Permissions.ManageEvent.FULL,

--- a/packages/common-lib/src/typings/types.ts
+++ b/packages/common-lib/src/typings/types.ts
@@ -309,6 +309,11 @@ export namespace Permissions {
 		NO = 'No',
 		YES = 'Yes',
 	}
+
+	export enum MemberSearch {
+		NO = 'No',
+		YES = 'Yes',
+	}
 }
 
 export type HTTPRequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
@@ -1524,6 +1529,10 @@ export interface CAPSquadronMemberPermissions {
 	 * Whether or not the member can view notifications designated for account admins
 	 */
 	ViewAccountNotifications: Permissions.ViewAccountNotifications;
+	/**
+	 * Whether or not the member can access the Member Search function
+	 */
+	MemberSearch: Permissions.MemberSearch;
 }
 
 /**
@@ -1605,6 +1614,10 @@ export interface CAPEventMemberPermissions {
 	 * Whether or not the member can view notifications designated for account admins
 	 */
 	ViewAccountNotifications: Permissions.ViewAccountNotifications;
+	/**
+	 * Whether or not the member can access the Member Search function
+	 */
+	MemberSearch: Permissions.MemberSearch;
 }
 
 export interface CAPGroupMemberPermissions {
@@ -1671,6 +1684,10 @@ export interface CAPGroupMemberPermissions {
 	 * Whether or not the member can view notifications designated for account admins
 	 */
 	ViewAccountNotifications: Permissions.ViewAccountNotifications;
+	/**
+	 * Whether or not the member can access the Member Search function
+	 */
+	MemberSearch: Permissions.MemberSearch;
 }
 
 export interface CAPWingMemberPermissions {
@@ -1741,6 +1758,10 @@ export interface CAPWingMemberPermissions {
 	 * Used for creating sub accounts
 	 */
 	CreateEventAccount: Permissions.CreateEventAccount;
+	/**
+	 * Whether or not the member can access the Member Search function
+	 */
+	MemberSearch: Permissions.MemberSearch;
 }
 
 export interface CAPRegionMemberPermissions {
@@ -1811,6 +1832,10 @@ export interface CAPRegionMemberPermissions {
 	 * Used for creating sub accounts
 	 */
 	CreateEventAccount: Permissions.CreateEventAccount;
+	/**
+	 * Whether or not the member can access the Member Search function
+	 */
+	MemberSearch: Permissions.MemberSearch;
 }
 
 export type MemberPermissions =


### PR DESCRIPTION
This code change adds the display of the Member Search widget as a function of specific permissions in addition to unit duty position.